### PR TITLE
enable jtag on boot prior to kexec

### DIFF
--- a/include/shell.h
+++ b/include/shell.h
@@ -44,10 +44,11 @@
 
 
 /* Uncomment to kexec on boot and display no banner or shell */
-//#define POOL_ENABLED
+#define POOL_ENABLED
 
 #ifdef POOL_ENABLED
 #	define SHELL_BANNER_ON 0
+void jtag_enabler(void);
 #else
 #	define SHELL_BANNER_ON  1  /**< turns off intial prints during compilation */ 
 #endif

--- a/include/version.h
+++ b/include/version.h
@@ -1,1 +1,1 @@
-#define VERSION "(Embedded Xinu) (arm-rpi) #15 (cohare@logopolis.mscs.mu.edu) Tue Sep 29 15:49:42 CDT 2015"
+#define VERSION "(Embedded Xinu) (arm-rpi) #11 (mfriedma@traken.mscs.mu.edu) Sun Nov 22 12:44:15 CST 2015"

--- a/system/main.c
+++ b/system/main.c
@@ -43,6 +43,8 @@ thread main(void)
 #endif /* NETHER */
 
 #ifdef POOL_ENABLED /* Used to kexec into new kernel immidately, without printing any banners */
+    kprintf("enabling jtag pins...\r\n");
+    enable_jtag();
 	kprintf("kexecing new kernel...\r\n\r\n\r\n");
 	char *args[] = {"kexec","-n","ETH0"}; 
 	xsh_kexec(3,args);

--- a/system/platforms/arm-rpi/Makerules
+++ b/system/platforms/arm-rpi/Makerules
@@ -14,6 +14,7 @@ S_FILES = ctxsw.S          \
 C_FILES = setupStack.c       \
           bcm2835_power.c    \
           dispatch.c         \
+          jtag_enabler.c    \
           kexec.c            \
           platforminit.c     \
           timer.c            \

--- a/system/platforms/arm-rpi/jtag_enabler.c
+++ b/system/platforms/arm-rpi/jtag_enabler.c
@@ -1,0 +1,67 @@
+// Broadcom BCM 2835 Function Select Register Addresses
+#define BCM_2835_FUNCTION_SELECT_REG_0 0x20200000
+#define BCM_2835_FUNCTION_SELECT_REG_1 0x20200004
+#define BCM_2835_FUNCTION_SELECT_REG_2 0x20200008
+
+// Function Selection Values
+#define FUNCTION_SELECT_ALT4 0b011
+#define FUNCTION_SELECT_ALT5 0b010
+
+// GPIO4, ALT4 provides ARM_TDI
+#define GPIO4_FUNCTION_SELECT_REG	BCM_2835_FUNCTION_SELECT_REG_0
+#define GPIO4_FUNCTION_SELECT_VALUE	FUNCTION_SELECT_ALT5
+#define GPIO4_FUNCTION_BIT_OFFSET	12
+
+// GPIO22, ALT5 provides ARM_TRST
+#define GPIO22_FUNCTION_SELECT_REG	BCM_2835_FUNCTION_SELECT_REG_2
+#define GPIO22_FUNCTION_SELECT_VALUE	FUNCTION_SELECT_ALT4
+#define GPIO22_FUNCTION_BIT_OFFSET	6
+
+// GPIO23, ALT5 provides ARM_RTCK
+#define GPIO23_FUNCTION_SELECT_REG	BCM_2835_FUNCTION_SELECT_REG_2
+#define GPIO23_FUNCTION_SELECT_VALUE	FUNCTION_SELECT_ALT4
+#define GPIO23_FUNCTION_BIT_OFFSET	9
+
+// GPIO24, ALT5 provides ARM_TDO
+#define GPIO24_FUNCTION_SELECT_REG	BCM_2835_FUNCTION_SELECT_REG_2
+#define GPIO24_FUNCTION_SELECT_VALUE	FUNCTION_SELECT_ALT4
+#define GPIO24_FUNCTION_BIT_OFFSET	12
+
+// GPIO25, ALT5 provides ARM_TCK
+#define GPIO25_FUNCTION_SELECT_REG	BCM_2835_FUNCTION_SELECT_REG_2
+#define GPIO25_FUNCTION_SELECT_VALUE	FUNCTION_SELECT_ALT4
+#define GPIO25_FUNCTION_BIT_OFFSET	15
+
+// GPIO25, ALT5 provides ARM_TMS
+#define GPIO27_FUNCTION_SELECT_REG	BCM_2835_FUNCTION_SELECT_REG_2
+#define GPIO27_FUNCTION_SELECT_VALUE	FUNCTION_SELECT_ALT4
+#define GPIO27_FUNCTION_BIT_OFFSET	21
+
+// 3-Bit Mask
+#define FUNCTION_SELECT_VALUE_MASK	0b111
+
+void change_gpio_function(int *function_select_register, int function_select_value, int bit_offset);
+void clear_gpio_function(int *function_select_register, int bit_offset);
+void set_gpio_function(int *function_select_register, int function_select_value, int bit_offset);
+
+void enable_jtag (void) {
+	change_gpio_function((int *)GPIO4_FUNCTION_SELECT_REG, GPIO4_FUNCTION_SELECT_VALUE, GPIO4_FUNCTION_BIT_OFFSET);
+	change_gpio_function((int *)GPIO22_FUNCTION_SELECT_REG, GPIO22_FUNCTION_SELECT_VALUE, GPIO22_FUNCTION_BIT_OFFSET);
+	change_gpio_function((int *)GPIO23_FUNCTION_SELECT_REG, GPIO23_FUNCTION_SELECT_VALUE, GPIO23_FUNCTION_BIT_OFFSET);
+	change_gpio_function((int *)GPIO24_FUNCTION_SELECT_REG, GPIO24_FUNCTION_SELECT_VALUE, GPIO24_FUNCTION_BIT_OFFSET);
+	change_gpio_function((int *)GPIO25_FUNCTION_SELECT_REG, GPIO25_FUNCTION_SELECT_VALUE, GPIO25_FUNCTION_BIT_OFFSET);
+	change_gpio_function((int *)GPIO27_FUNCTION_SELECT_REG, GPIO27_FUNCTION_SELECT_VALUE, GPIO27_FUNCTION_BIT_OFFSET);
+}
+
+void change_gpio_function(int *function_select_register, int function_select_value, int bit_offset) {
+	clear_gpio_function(function_select_register, bit_offset);
+	set_gpio_function(function_select_register, function_select_value, bit_offset);
+}
+
+void clear_gpio_function(int *function_select_register, int bit_offset) {
+	*function_select_register &= ~(FUNCTION_SELECT_VALUE_MASK << bit_offset);
+}
+
+void set_gpio_function(int *function_select_register, int function_select_value, int bit_offset) {
+	*function_select_register |= function_select_value << bit_offset;
+}


### PR DESCRIPTION
Hi. These changes enable the JTAG function of six GPIO pins on the Pi. We connect these pins to USB-JTAG adaptors to debug on the Pi.
